### PR TITLE
Fix cyclic inclusion of scenes

### DIFF
--- a/scenes/Endscrin.gd
+++ b/scenes/Endscrin.gd
@@ -1,6 +1,6 @@
 extends Container
 
-onready var TitleScreen = preload("res://scenes/Titlescreen_stupid.tscn")
+onready var TitleScreen = load("res://scenes/Titlescreen_stupid.tscn")
 
 func initialize(var winnerNumber):
 	var winnerNode = null

--- a/scenes/GameController.gd
+++ b/scenes/GameController.gd
@@ -3,7 +3,7 @@ extends Node2D
 var spawns = []
 var activePlayers = [null, null, null]
 onready var TitleScreen = load("res://scenes/Titlescreen_stupid.tscn")
-onready var EndScreen = preload("res://scenes/Endscrin.tscn")
+onready var EndScreen = load("res://scenes/Endscrin.tscn")
 
 func _ready():
 	spawns = $Spawns.get_children()

--- a/scenes/GameController.gd
+++ b/scenes/GameController.gd
@@ -2,7 +2,7 @@ extends Node2D
 
 var spawns = []
 var activePlayers = [null, null, null]
-onready var TitleScreen = preload("res://scenes/Titlescreen_stupid.tscn")
+onready var TitleScreen = load("res://scenes/Titlescreen_stupid.tscn")
 onready var EndScreen = preload("res://scenes/Endscrin.tscn")
 
 func _ready():


### PR DESCRIPTION
This may or may not fix the export not working correctly. This is based on the following two error messages I receive when opening / exporting your game locally:

> ERROR: set_path: Another resource is loaded from path: res://scenes/GameController.tscn (possible cyclic resource inclusion)
   At: core/resource.cpp:78.
ERROR: set_path: Another resource is loaded from path: res://scenes/Titlescreen_stupid.tscn (possible cyclic resource inclusion)
   At: core/resource.cpp:78.

Let's see what Travis has to say about this.